### PR TITLE
Add missing log that point to a failed Generation

### DIFF
--- a/gemma.cc
+++ b/gemma.cc
@@ -584,6 +584,9 @@ void GenerateImpl(GemmaImpl<TConfig>& gemma, size_t max_tokens,
     } else if ((prompt.size() + max_generated_tokens) > max_tokens) {
       std::cout << "Warning: Prompt size + max_new_tokens exceeds max_tokens."
                 << std::endl;
+    } else if (pos >= max_tokens) {
+      std::cout << "Warning: pos exceeds max_tokens."
+                << std::endl;
     }
   }
 


### PR DESCRIPTION
if `pos >= max_tokens`, the next `for` will not be run.