### PR TITLE
Added a missing space in app.h

### DIFF
--- a/util/app.h
+++ b/util/app.h
@@ -199,7 +199,7 @@ struct LoaderArgs : public ArgsBase<LoaderArgs> {
     visitor(weights, "weights", Path(),
             "Path name of model weights (.sbs) file. Only required if "
             "compressed_weights file is not present and needs to be "
-            "regenerated. This parameter is only required for compressing"
+            "regenerated. This parameter is only required for compressing "
             "new model weight exports, otherwise it is not needed.");
   }
 };


### PR DESCRIPTION
When the user runs `--help`, they see the non-existent word `compressingnew`. This is because of a missing space, which is now added, resulting in `compressing new`.