### PR TITLE
.bazelrc: Set --cxxopt to C++17 standard

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,5 @@
 common --enable_bzlmod
+
+build --cxxopt="-std=c++17"
+
+test --cxxopt="-std=c++17"


### PR DESCRIPTION
Gemma requires C++17, but this is not explicitly specified by default.

This change adds `--cxxopt` for `build` and `test` subcommands, which resolves the following error symptom when building as `bazelisk build //...`:

```
ERROR: [elided]/gemma.cpp/BUILD.bazel:84:10: Compiling run.cc failed: (Exit 1): gcc failed: error executing CppCompile command (from target //:gemma) /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++14' -MD -MF bazel-out/k8-fastbuild/bin/_objs/gemma/run.pic.d ... (remaining 60 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from run.cc:32:
util/app.h: In member function 'void gcpp::AppArgs::ChooseNumThreads()':
util/app.h:92:46: error: 'clamp' is not a member of 'std'
   92 |       num_threads = static_cast<size_t>(std::clamp(
      |                                              ^~~~~
run.cc: At global scope:
run.cc:46:23: error: 'string_view' in namespace 'std' does not name a type
   46 | static constexpr std::string_view kAsciiArtBanner =
      |                       ^~~~~~~~~~~
run.cc:46:18: note: 'std::string_view' is only available from C++17 onwards
   46 | static constexpr std::string_view kAsciiArtBanner =
      |                  ^~~
run.cc: In function 'void gcpp::ShowHelp(gcpp::LoaderArgs&, gcpp::InferenceArgs&, gcpp::AppArgs&)':
run.cc:81:10: error: 'kAsciiArtBanner' was not declared in this scope
   81 |       << kAsciiArtBanner
      |          ^~~~~~~~~~~~~~~
run.cc: In function 'void gcpp::ReplGemma(gcpp::Gemma&, gcpp::KVCache&, hwy::ThreadPool&, hwy::ThreadPool&, const gcpp::InferenceArgs&, int, const AcceptFunc&, std::string&)':
run.cc:150:18: warning: comparison of integer expressions of different signedness: 'int' and 'const size_t' {aka 'const long unsigned int'} [-Wsign-compare]
  150 |   while (abs_pos < args.max_tokens) {
      |          ~~~~~~~~^~~~~~~~~~~~~~~~~
run.cc: In function 'void gcpp::Run(gcpp::LoaderArgs&, gcpp::InferenceArgs&, gcpp::AppArgs&)':
run.cc:264:18: error: 'kAsciiArtBanner' was not declared in this scope
  264 |               << kAsciiArtBanner << "\n\n";
      |                  ^~~~~~~~~~~~~~~
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 1.172s, Critical Path: 0.76s
INFO: 260 processes: 249 disk cache hit, 11 internal.
ERROR: Build did NOT complete successfully
```