### PR TITLE
Fix off-by-one errors in generation code and token streaming callback.

### DIFF
--- a/run.cc
+++ b/run.cc
@@ -116,7 +116,8 @@ void ReplGemma(gcpp::Gemma& model, gcpp::KVCache& kv_cache,
                        verbosity](int token, float) {
     ++abs_pos;
     ++current_pos;
-    if (current_pos < prompt_size) {
+    // <= since position is incremented before
+    if (current_pos <= prompt_size) {
       std::cerr << "." << std::flush;
     } else if (token == gcpp::EOS_ID) {
       if (!args.multiturn) {


### PR DESCRIPTION
In the generation code we were feeding the last token of the prompt twice through the transformer. The new version fixes that and also works in the case where Prefill is completely disabled.