### PR TITLE
Clarified README

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ here provide a C++ implementation of this model based on the paper.
 
 To use the recurrent version of Gemma included in this repository, build the
 gemma binary as noted above in Step 3. Download the compressed weights and
-tokenizer from
+tokenizer from the RecurrentGemma
 [Kaggle](https://www.kaggle.com/models/google/recurrentgemma/gemmaCpp) as in
 Step 1, and run the binary as follows:
 


### PR DESCRIPTION
Made it more visible that the recurrent weights are at a different Kaggle page.