### PR TITLE
Factor out deinterleaving of bf16 vectors for MatVecs.

### DIFF
--- a/compression/compress-inl.h
+++ b/compression/compress-inl.h
@@ -72,7 +72,7 @@ struct CompressTraits {};
 template <>
 struct CompressTraits<float> {
   using MatT = float;
-  static constexpr bool supports_eo = false;
+  static constexpr bool kSupportsEvenOdd = false;
 
   template <class DF, HWY_IF_F32_D(DF)>
   static HWY_INLINE void Compress(DF df, const float* HWY_RESTRICT in,
@@ -126,7 +126,7 @@ struct CompressTraits<float> {
 template <>
 struct CompressTraits<hwy::bfloat16_t> {
   using MatT = hwy::bfloat16_t;
-  static constexpr bool supports_eo = true;
+  static constexpr bool kSupportsEvenOdd = true;
 
   template <class DF, HWY_IF_F32_D(DF)>
   static HWY_INLINE void Compress(DF df, const float* HWY_RESTRICT in,
@@ -288,7 +288,7 @@ struct CompressTraits<hwy::bfloat16_t> {
 template <>
 struct CompressTraits<SfpStream> {
   using MatT = SfpStream;
-  static constexpr bool supports_eo = false;
+  static constexpr bool kSupportsEvenOdd = false;
 
   template <class DF, HWY_IF_F32_D(DF)>
   static HWY_INLINE void Compress(DF df, const float* in, size_t num,
@@ -338,7 +338,7 @@ struct CompressTraits<SfpStream> {
 template <>
 struct CompressTraits<NuqStream> {
   using MatT = NuqStream;
-  static constexpr bool supports_eo = false;
+  static constexpr bool kSupportsEvenOdd = false;
 
   template <class DF, HWY_IF_F32_D(DF)>
   static HWY_INLINE void Compress(DF df, const float* in, size_t num,

--- a/gemma/ops.h
+++ b/gemma/ops.h
@@ -181,7 +181,7 @@ HWY_INLINE void MatVecLoop(const ArrayT& mat, const size_t mat_ofs,
                            const VecT* HWY_RESTRICT vec_aligned,
                            float* HWY_RESTRICT out) {
   MatVecAddLoop<false, kOuter, kInner>(
-      mat, mat_ofs, vec_aligned, /*add=*/(VecT*)nullptr, out);
+      mat, mat_ofs, vec_aligned, /*add=*/static_cast<VecT*>(nullptr), out);
 }
 
 // Simple version without tiling nor threading, but two offsets/outputs.
@@ -420,7 +420,8 @@ HWY_INLINE void MatVec(const ArrayT& mat, const size_t mat_ofs,
                        const VecT* HWY_RESTRICT const vec_aligned,
                        float* HWY_RESTRICT out, hwy::ThreadPool& pool) {
   MatVecAdd<false, kOuter, kInner>(
-      mat, mat_ofs, vec_aligned, /*add=*/(VecT *)nullptr, out, pool);
+      mat, mat_ofs, vec_aligned, /*add=*/static_cast<VecT*>(nullptr), out,
+      pool);
 }
 
 template <class D, HWY_IF_F32_D(D)>

--- a/gemma/ops.h
+++ b/gemma/ops.h
@@ -98,7 +98,6 @@ HWY_INLINE void ToEvenOddF32(
   const hn::ScalableTag<float> df;
   const hn::Repartition<hwy::bfloat16_t, decltype(df)> dbf16;
   const hn::RebindToUnsigned<decltype(df)> du32;
-  const auto odd = Set(du32, 0xFFFF0000u);
   using VF32 = decltype(hn::Zero(df));
 
   HWY_DASSERT(size % hn::Lanes(dbf16) == 0);
@@ -361,9 +360,7 @@ HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
                           float* HWY_RESTRICT out, hwy::ThreadPool& pool) {
   PROFILER_ZONE("MatVecAdd");
 
-  const hn::ScalableTag<float> df;
   constexpr size_t kRowsPerStrip = RowsPerStrip<kOuter>();
-  constexpr size_t kNumStrips = kOuter / kRowsPerStrip;
 
   #if !defined(HWY_NATIVE_DOT_BF16) || !HWY_NATIVE_DOT_BF16
   if constexpr (

--- a/gemma/ops.h
+++ b/gemma/ops.h
@@ -104,11 +104,10 @@ HWY_INLINE void ToEvenOddF32(
   HWY_DASSERT(size % hn::Lanes(dbf16) == 0);
   HWY_DASSERT(hn::IsAligned(df, vec_aligned));
 
-  VF32 veven, vodd;
   for (size_t i = 0; i < size; i += hn::Lanes(dbf16)) {
-    Bf16ToF32EO(df, vec_aligned + i, veven, vodd);
-    hn::Store(veven, df, out + i);
-    hn::Store(vodd, df, out + i + hn::Lanes(df));
+    const auto interleaved = hn::LoadU(dbf16, vec_aligned + i);
+    hn::Store(hn::PromoteEvenTo(df, interleaved), df, out + i);
+    hn::Store(hn::PromoteOddTo(df, interleaved), df, out + i + hn::Lanes(df));
   }
 }
 

--- a/gemma/ops.h
+++ b/gemma/ops.h
@@ -339,51 +339,15 @@ HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
 // A specialization of MatVecAdd to float32 vectors which first rearranges the
 // vector to even-odd layout.
 template <bool kAdd, size_t kOuter, size_t kInner, typename ArrayT,
-          typename AddT,
+          typename VecT, typename AddT,
+          std::enable_if_t<
+            std::is_same_v<VecT, float> || std::is_same_v<VecT, hwy::bfloat16_t>>
+            = true,
           std::enable_if_t<
             CompressTraits<typename ArrayT::value_type>::kSupportsEvenOdd, bool>
             = true>
 HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
-                          const float* HWY_RESTRICT const vec_aligned,
-                          const AddT* HWY_RESTRICT const add,
-                          float* HWY_RESTRICT out, hwy::ThreadPool& pool) {
-  PROFILER_ZONE("MatVecAdd");
-
-  const hn::ScalableTag<float> df;
-  constexpr size_t kRowsPerStrip = RowsPerStrip<kOuter>();
-  constexpr size_t kNumStrips = kOuter / kRowsPerStrip;
-
-  const auto vec_dequant = hwy::AllocateAligned<float>(kInner);
-  ToEvenOddF32(vec_aligned, kInner, vec_dequant.get());
-
-  // For each entire strip.
-  pool.Run(0, kNumStrips, [&](const uint64_t strip, size_t thread) HWY_ATTR {
-    PROFILER_ZONE("MatVec.lambda");
-    const size_t r0 = strip * kRowsPerStrip;
-    detail::FullDotProductsForStrip<true, kAdd>(
-      df, mat, mat_ofs, kInner, r0, kRowsPerStrip, vec_dequant.get(), add,
-      out + r0);
-  });
-
-  // Remaining rows
-  const size_t r0 = kNumStrips * kRowsPerStrip;
-  if (r0 < kOuter) {
-    PROFILER_ZONE("MatVec remainder");
-    const size_t num_rows = kOuter - r0;
-    detail::FullDotProductsForStrip<true, kAdd>(
-      df, mat, mat_ofs, kInner, r0, num_rows, vec_dequant.get(), add, out + r0);
-  }
-}
-
-// A specialization of MatVecAdd to bf16 vectors which first rearranges the
-// vector to even-odd layout.
-template <bool kAdd, size_t kOuter, size_t kInner, typename ArrayT,
-          typename AddT,
-          std::enable_if_t<
-            CompressTraits<typename ArrayT::value_type>::kSupportsEvenOdd, bool>
-            = true>
-HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
-                          const hwy::bfloat16_t* HWY_RESTRICT const vec_aligned,
+                          const VecT* HWY_RESTRICT const vec_aligned,
                           const AddT* HWY_RESTRICT const add,
                           float* HWY_RESTRICT out, hwy::ThreadPool& pool) {
   PROFILER_ZONE("MatVecAdd");

--- a/gemma/ops.h
+++ b/gemma/ops.h
@@ -341,7 +341,9 @@ HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
 // vector to even-odd layout.
 template <bool kAdd, size_t kOuter, size_t kInner, typename ArrayT,
           typename AddT,
-          std::enable_if_t<CompressTraits<typename ArrayT::value_type>::supports_eo, bool> = true>
+          std::enable_if_t<
+            CompressTraits<typename ArrayT::value_type>::kSupportsEvenOdd, bool>
+            = true>
 HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
                           const float* HWY_RESTRICT const vec_aligned,
                           const AddT* HWY_RESTRICT const add,
@@ -378,7 +380,9 @@ HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
 // vector to even-odd layout.
 template <bool kAdd, size_t kOuter, size_t kInner, typename ArrayT,
           typename AddT,
-          std::enable_if_t<CompressTraits<typename ArrayT::value_type>::supports_eo, bool> = true>
+          std::enable_if_t<
+            CompressTraits<typename ArrayT::value_type>::kSupportsEvenOdd, bool>
+            = true>
 HWY_INLINE void MatVecAdd(const ArrayT& mat, const size_t mat_ofs,
                           const hwy::bfloat16_t* HWY_RESTRICT const vec_aligned,
                           const AddT* HWY_RESTRICT const add,


### PR DESCRIPTION
This specializes bf16-f32 and bf16-bf16 vector-matrix multiplications to first convert bf16 vectors into f32 buffers of vector-length strips of even- and odd-indexed values.

The 2B, bf16 model running on my Zen 1 machine sees ~10% throughput improvements to single-threaded prefill, single-threaded generation, and multi-threaded prefill, but only a marginal improvement to multi-threaded generation throughput.

This PR does not implement support for SFP.

## TODOs:
- [x] Check for native BF16 support.
- [x] Lift out allocations of f32 vectors. (@jan-wassenberg volunteered to handle this.)
- [x] Clean up some MatVecAdd code duplication.