### PR TITLE
work with cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,15 +72,17 @@ set_property(TARGET libgemma PROPERTY CXX_STANDARD 17)
 set_target_properties(libgemma PROPERTIES PREFIX "")
 set_property(TARGET libgemma PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(libgemma PUBLIC ./)
-target_link_libraries(libgemma hwy hwy_contrib sentencepiece)
+target_link_libraries(libgemma hwy hwy_contrib sentencepiece-static)
 target_include_directories(libgemma PUBLIC ${sentencepiece_SOURCE_DIR})
 target_compile_definitions(libgemma PRIVATE $<$<PLATFORM_ID:Windows>:_CRT_SECURE_NO_WARNINGS NOMINMAX>)
 target_compile_options(libgemma PRIVATE $<$<PLATFORM_ID:Windows>:-Wno-deprecated-declarations>)
+install(TARGETS libgemma DESTINATION lib)
 
 # Executable Target
 
 add_executable(gemma run.cc)
 target_link_libraries(gemma libgemma hwy hwy_contrib)
+install(TARGETS gemma DESTINATION bin)
 
 add_executable(benchmark benchmark.cc)
 target_link_libraries(benchmark libgemma hwy hwy_contrib nlohmann_json::nlohmann_json)


### PR DESCRIPTION
currently, gemma only works at `build` dir, it better to support `cmake --install` to install the build output to system directory and easy to use `gemma` globally. I made two changes:
1. allow `gemma` and `libgemma` to be install; 
2. change `target_link_libraries` of `sentencepiece` to `sentencepiece-static`, so that the build output is portable