### PR TITLE
Use more parallelism in attention block in prefill mode.

### DIFF
--- a/compression/compress-inl.h
+++ b/compression/compress-inl.h
@@ -247,7 +247,6 @@ struct CompressTraits<hwy::bfloat16_t> {
     using VU32 = hn::VFromD<decltype(du32)>;
     const VU32 odd = Set(du32, 0xFFFF0000u);
 
-    VF32 be0, bo0, be1, bo1;
     for (size_t i = 0; i < num; /* i += 2 * N */) {
       const auto interleaved0 = hn::LoadU(dbf16, in + in_ofs + i);
       const VF32 ae0 = Load(df32, vec_aligned + i);

--- a/gemma/gemma.cc
+++ b/gemma/gemma.cc
@@ -845,7 +845,7 @@ template <size_t kBatchSize, typename LayerT, typename TConfig>
 HWY_NOINLINE void FFW(Activations<TConfig, kBatchSize>& activations,
                       size_t num_tokens, const LayerT* layer_weights,
                       hwy::ThreadPool& pool) {
-  HWY_DASSERT(batch_idx < kBatchSize);
+  HWY_DASSERT(num_tokens <= kBatchSize);
   static constexpr size_t kModelDim = TConfig::kModelDim;
   static constexpr size_t kFFHiddenDim = TConfig::kFFHiddenDim;
   float* HWY_RESTRICT even_odd = activations.even_odd.data();

--- a/gemma/gemma.cc
+++ b/gemma/gemma.cc
@@ -585,7 +585,6 @@ HWY_NOINLINE void GriffinRecurrent(
   // X / Y linear layers.
   for (size_t batch_idx = 0; batch_idx < num_tokens; ++batch_idx) {
     const size_t batch_offset = batch_idx * kModelDim;
-    const size_t pos = batch_start + batch_idx;
     float* HWY_RESTRICT y = activations.griffin_y.data() + batch_offset;
     float* HWY_RESTRICT x = activations.griffin_x.data() + batch_offset;
     TwoMatVecAdd<kAdd, kModelDim, kModelDim>(
@@ -691,7 +690,6 @@ HWY_NOINLINE void GriffinRecurrent(
   // Final linear layer.
   for (size_t batch_idx = 0; batch_idx < num_tokens; ++batch_idx) {
     const size_t batch_offset = batch_idx * kModelDim;
-    const size_t pos = batch_start + batch_idx;
     float* HWY_RESTRICT x = activations.griffin_x.data() + batch_offset;
     float* out_ptr = activations.att_post2.data() + batch_idx * kModelDim;
     MatVecAdd<kAdd, kModelDim, kModelDim>(


### PR DESCRIPTION
Move the loop over the tokens inside the attention block and then create kHeads * num_tokens threads.

This helps the multi-threaded speed only in case of the 2b gemma model, but to be consistent we move the loop over the tokens inside the griffin recurrent layer and the FFW layer as well. This is also a preparation for using the MatMul operation later.

Benchmark results (summarization with 1600 tokens for prefill and essay writing with 500 tokens for generation):

```
                   Prefill speed
Num threads      BEFORE       AFTER
32               61.76 t/s    65.08 t/s
64               89.46 t/s    98.62 t/s
```