### PR TITLE
Fix compilation errors in clang

### DIFF
--- a/gemma/weights.h
+++ b/gemma/weights.h
@@ -232,7 +232,7 @@ void LogWeightStats(Model model, Type weight_type, const ByteStorageT& weights);
 template <class TConfig, class RawLayer = void, class RawWeightsPtr, class Func>
 void ForEachTensor(RawWeightsPtr raw_weights,
                    CompressedWeights<TConfig>& c_weights, Func& func) {
-  constexpr bool kHaveRaw = !hwy::IsSame<RawWeightsPtr, nullptr_t>();
+  constexpr bool kHaveRaw = !hwy::IsSame<RawWeightsPtr, std::nullptr_t>();
 
   GEMMA_CALL_TOP_FUNC("c_embedding", embedder_input_embedding);
   GEMMA_CALL_TOP_FUNC("c_final_norm", final_norm_scale);


### PR DESCRIPTION
It will occur in `ubuntu-latest` of GitHub Actions:

```
In file included from /home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/backprop/optimizer.cc:23:
/home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/./gemma/weights.h:235:57: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
  constexpr bool kHaveRaw = !hwy::IsSame<RawWeightsPtr, nullptr_t>();
                                                        ^~~~~~~~~
                                                        std::nullptr_t
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/x86_64-linux-gnu/c++/12/bits/c++config.h:302:29: note: 'std::nullptr_t' declared here
  typedef decltype(nullptr)     nullptr_t;
                                ^
In file included from /home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/./backprop/backward.cc:27:
In file included from /home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/highway-src/hwy/foreach_target.h:72:
In file included from /home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/./backprop/backward.cc:32:
/home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/./gemma/weights.h:235:57: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
  constexpr bool kHaveRaw = !hwy::IsSame<RawWeightsPtr, nullptr_t>();
                                                        ^~~~~~~~~
                                                        std::nullptr_t
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/x86_64-linux-gnu/c++/12/bits/c++config.h:302:29: note: 'std::nullptr_t' declared here
  typedef decltype(nullptr)     nullptr_t;
                                ^
In file included from /home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/./backprop/forward.cc:27:
In file included from /home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/highway-src/hwy/foreach_target.h:72:
In file included from /home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/./backprop/forward.cc:32:
/home/runner/work/lua-cgemma/lua-cgemma/lua-cgemma/build/_deps/gemma-src/./gemma/weights.h:235:57: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
  constexpr bool kHaveRaw = !hwy::IsSame<RawWeightsPtr, nullptr_t>();
                                                        ^~~~~~~~~
                                                        std::nullptr_t
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/x86_64-linux-gnu/c++/12/bits/c++config.h:302:29: note: 'std::nullptr_t' declared here
  typedef decltype(nullptr)     nullptr_t;
                                ^
1 error generated.
make[2]: *** [_deps/gemma-build/CMakeFiles/libgemma.dir/build.make:146: _deps/gemma-build/CMakeFiles/libgemma.dir/backprop/optimizer.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
1 error generated.
make[2]: *** [_deps/gemma-build/CMakeFiles/libgemma.dir/build.make:[118](https://github.com/ufownl/lua-cgemma/actions/runs/9608690735/job/26501927754#step:6:119): _deps/gemma-build/CMakeFiles/libgemma.dir/backprop/backward.cc.o] Error 1
1 error generated.
make[2]: *** [_deps/gemma-build/CMakeFiles/libgemma.dir/build.make:132: _deps/gemma-build/CMakeFiles/libgemma.dir/backprop/forward.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:600: _deps/gemma-build/CMakeFiles/libgemma.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
Error: Process completed with exit code 2.
```