### PR TITLE
Implement `start_pos` per query for batch interface

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,10 +58,10 @@ cc_test(
 )
 
 cc_test(
-    name = "matvec_test",
+    name = "gemma_matvec_test",
     size = "small",
     timeout = "long",
-    srcs = ["ops/matvec_test.cc"],
+    srcs = ["ops/gemma_matvec_test.cc"],
     local_defines = ["HWY_IS_TEST"],
     # for test_suite.
     tags = ["hwy_ops_test"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ set(GEMMA_TEST_FILES
   backprop/optimize_test.cc
   ops/ops_test.cc
   ops/matmul_test.cc
-  ops/matvec_test.cc
+  ops/gemma_matvec_test.cc
   evals/gemma_test.cc
 )
 

--- a/evals/benchmark_helper.cc
+++ b/evals/benchmark_helper.cc
@@ -171,7 +171,8 @@ std::vector<std::pair<std::string, size_t>> GemmaEnv::BatchQueryModel2(
   gcpp::TimingInfo timing_info = {.verbosity = app_.verbosity};
   runtime_config_.batch_stream_token = batch_stream_token;
   inference_args_.CopyTo(runtime_config_);
-  model_->GenerateBatch(runtime_config_, prompts, /*start_pos=*/0,
+  model_->GenerateBatch(runtime_config_, prompts,
+                        std::vector<size_t>(num_queries, 0),
                         KVCaches(&kv_caches_[0], num_queries), timing_info);
   return res;
 }

--- a/gemma/gemma-inl.h
+++ b/gemma/gemma-inl.h
@@ -987,7 +987,8 @@ void GenerateT(const ByteStorageT& weights_u8, Activations& activations,
   TokenStreamer token_streamer(runtime_config);
   for (size_t query_idx = 0; query_idx < num_queries; ++query_idx) {
     gen_tokens[query_idx] = prompts[query_idx][prefill_per_query];
-    (void)token_streamer(query_idx_start + query_idx, prefill_per_query,
+    (void)token_streamer(query_idx_start + query_idx,
+                         pos[query_idx] + prefill_per_query,
                          gen_tokens[query_idx], 0.0f);
   }
 
@@ -1020,9 +1021,10 @@ void GenerateT(const ByteStorageT& weights_u8, Activations& activations,
       const int token = sample_token(logits, kVocabSize);
       timing_info.NotifyGenerated(prefill_start, gen_start);
 
-      const bool is_eos = token_streamer(query_idx_start + query_idx,
-                                         prefill_per_query + 1 + gen_per_query,
-                                         token, logits[token]);
+      const bool is_eos =
+          token_streamer(query_idx_start + query_idx,
+                         pos[query_idx] + prefill_per_query + 1 + gen_per_query,
+                         token, logits[token]);
       all_queries_eos &= is_eos;
       gen_tokens[query_idx] = is_eos ? runtime_config.eos_id : token;
     }

--- a/gemma/gemma.cc
+++ b/gemma/gemma.cc
@@ -66,7 +66,8 @@ Gemma::~Gemma() {
                              TimingInfo& timing_info);                         \
   extern void GenerateBatch(CONFIGT<TWEIGHT>, const ByteStorageT& weights_u8,  \
                             const RuntimeConfig& runtime_config,               \
-                            const MultiplePromptsTokens& prompts, size_t pos,  \
+                            const MultiplePromptsTokens& prompts,              \
+                            const MultiplePositions& pos,                      \
                             const KVCaches& kv_caches, PerClusterPools& pools, \
                             TimingInfo& timing_info);
 GEMMA_FOREACH_CONFIG_AND_WEIGHT(GEMMA_DECLARE);
@@ -87,9 +88,9 @@ template <class TConfig>
 struct GenerateBatchT {
   void operator()(const ByteStorageT& weights_u8,
                   const RuntimeConfig& runtime_config,
-                  const MultiplePromptsTokens& prompts, size_t pos,
-                  const KVCaches& kv_caches, PerClusterPools& pools,
-                  TimingInfo& timing_info) const {
+                  const MultiplePromptsTokens& prompts,
+                  const MultiplePositions& pos, const KVCaches& kv_caches,
+                  PerClusterPools& pools, TimingInfo& timing_info) const {
     GenerateBatch(TConfig(), weights_u8, runtime_config, prompts, pos,
                   kv_caches, pools, timing_info);
   }
@@ -109,8 +110,8 @@ void Gemma::Generate(const RuntimeConfig& runtime_config,
 
 void Gemma::GenerateBatch(const RuntimeConfig& runtime_config,
                           const MultiplePromptsTokens& prompts,
-                          size_t start_pos, const KVCaches& kv_caches,
-                          TimingInfo& timing_info) {
+                          const MultiplePositions& start_pos,
+                          const KVCaches& kv_caches, TimingInfo& timing_info) {
   pools_.StartSpinning();
 
   CallForModelAndWeight<GenerateBatchT>(info_.model, info_.weight, weights_u8_,

--- a/gemma/gemma.h
+++ b/gemma/gemma.h
@@ -143,6 +143,7 @@ struct TimingInfo {
 
 using PromptTokens = hwy::Span<const int>;
 using MultiplePromptsTokens = hwy::Span<const PromptTokens>;
+using MultiplePositions = hwy::Span<const size_t>;
 using KVCaches = hwy::Span<KVCache>;
 
 class Gemma {
@@ -164,7 +165,8 @@ class Gemma {
                 size_t start_pos, KVCache& kv_cache, TimingInfo& timing_info);
 
   void GenerateBatch(const RuntimeConfig& runtime_config,
-                     const MultiplePromptsTokens& prompts, size_t start_pos,
+                     const MultiplePromptsTokens& prompts,
+                     const MultiplePositions& start_pos,
                      const KVCaches& kv_caches, TimingInfo& timing_info);
 
  private:

--- a/ops/gemma_matvec_test.cc
+++ b/ops/gemma_matvec_test.cc
@@ -33,7 +33,7 @@
 
 // clang-format off
 #undef HWY_TARGET_INCLUDE
-#define HWY_TARGET_INCLUDE "ops/matvec_test.cc"  // NOLINT
+#define HWY_TARGET_INCLUDE "ops/gemma_matvec_test.cc"  // NOLINT
 // clang-format on
 #include "hwy/foreach_target.h"  // IWYU pragma: keep
 #include "hwy/highway.h"


### PR DESCRIPTION
Refs #338

I noticed that the original padding code is not used, and the current implementation truncates the prompts to align to the shortest length to avoid accessing out-of-range. So before calling the batch interface, users should insert `<pad>` tokens in the front of the prompts to align them to the maximum length.