### PR TITLE
Fix compilation errors of "compress_weights" target

### DIFF
--- a/compression/compress.h
+++ b/compression/compress.h
@@ -444,8 +444,10 @@ class CompressStats {
   char padding_[64];  // prevent false sharing
 };
 #else
+class DistortionStats;
+
 struct CompressStats {
-  void Notify(...) {}
+  void Notify(const DistortionStats&) {}
   void NotifyIn(int) {}
   void Assimilate(const CompressStats&) {}
   void PrintAll() {}


### PR DESCRIPTION
This PR fixes the error:

```
error: cannot pass object of non-trivial type 'DistortionStats' through variadic method; call will abort at runtime [-Wnon-pod-varargs]
```