### PR TITLE
Fix the wrapping field of the deduced model config

### DIFF
--- a/gemma/model_store.cc
+++ b/gemma/model_store.cc
@@ -241,7 +241,7 @@ static ModelConfig ReadOrDeduceConfig(BlobReader& reader,
 
   // Pre-2025 format: no config, rely on deduction plus `wrapping_override`.
   return ModelConfig(deduced_model, deduced_weight,
-                     ChooseWrapping(config.model, wrapping_override));
+                     ChooseWrapping(deduced_model, wrapping_override));
 }
 
 static std::vector<float> ReadScales(BlobReader& reader,


### PR DESCRIPTION
It looks like a typo. :)

But, there is another issue when generating with an image:

```
[ Reading prompt ] Abort at gemma-inl.h:1086: Assert prefix_end_this_query == 0 || max_tbatch_size >= prefill_this_query: 
Aborted (core dumped)
```