### PR TITLE
Minor fixes for ViT

### DIFF
--- a/gemma/gemma-inl.h
+++ b/gemma/gemma-inl.h
@@ -1556,7 +1556,6 @@ void GenerateImageTokensT(const ModelStore& model,
   prefill_runtime_config.prefill_tbatch_size =
       vit_config.seq_len / (vit_config.pool_dim * vit_config.pool_dim);
   Activations prefill_activations(vit_config, vit_config.seq_len, env);
-  prefill_activations.SetBatchSize(prefill_runtime_config.prefill_tbatch_size);
   // Weights are for the full PaliGemma model, not just the ViT part.
   PrefillVit(weights, prefill_runtime_config, image, image_tokens,
              prefill_activations);


### PR DESCRIPTION
* Fix the incorrect batch size setting for `prefill_activations` in `PrefillVit` function.
* Fix incorrect `prefix_end` and `prefill_tbatch_size` settings for PaliGemma and Gemma3 in the CLI frontend.
* Fix the output of the CLI frontend.

After fixing these issues, the assertion failure will no longer be triggered, but ViT still does not work properly. I compared the image tokens generated by the main and dev branches, and the values ​​of the corresponding positions are unequal. There should be issues with the weight processing of the ViT part. I tried to look into it, but I have no idea yet.