### PR TITLE
Fix the ViT weights loading

### DIFF
--- a/gemma/weights.h
+++ b/gemma/weights.h
@@ -224,7 +224,7 @@ struct LayerWeightsPtrs {
       func(TENSOR_ARGS(vit.attn_out_w, kMustRead));
       func(TENSOR_ARGS(vit.attn_out_b, kMustRead));
       func(TENSOR_ARGS(vit.qkv_einsum_w, kMustRead));
-      func(TENSOR_ARGS(vit.qkv_einsum_b, kMustRead));
+      func(TENSOR_ARGS(vit.qkv_einsum_b, kMustRead | TensorArgs::kNoPad));
       // MlpBlock.
       func(TENSOR_ARGS(vit.linear_0_w, kMustRead));
       func(TENSOR_ARGS(vit.linear_0_b, kMustRead));


### PR DESCRIPTION
The shape of `qkv_einsum_b` is 2D `(3 * heads, QKV dims)`, and its backend pointer will be passed into `MatMul` to do element-wise addition via `PackedScale1` method, so it must have no padding.

I checked the implementation of `MatPtr` and its derived classes and found that the assertions about packed and scale are available only in debug builds, making these bugs very hard to catch. Should we change them to the version available in the release builds?