### PR TITLE
Fix integer overflow in tensor dimensions and PPM parser

### DIFF
--- a/paligemma/image.cc
+++ b/paligemma/image.cc
@@ -140,11 +140,11 @@ bool Image::ReadPPM(const hwy::Span<const char>& buf) {
   }
   ++pos;
   if (width == 0 || height == 0) {
-    std::cerr << "Invalid zero dimension\n";
+    HWY_ABORT("Invalid zero dimension\n");
     return false;
   }
   if (width > SIZE_MAX / 3 || width * 3 > SIZE_MAX / height) {
-    std::cerr << "Image dimensions overflow\n";
+    HWY_ABORT("Image dimensions overflow\n");
     return false;
   }
   const size_t data_size = width * height * 3;

--- a/paligemma/image.cc
+++ b/paligemma/image.cc
@@ -83,8 +83,11 @@ const char* ParseUnsigned(const char* pos, const char* end, size_t& num) {
   }
   num = 0;
   for (; pos < end && std::isdigit(*pos); ++pos) {
-    num *= 10;
-    num += *pos - '0';
+    const size_t digit = *pos - '0';
+    if (num > (SIZE_MAX - digit) / 10) {
+      return nullptr;  // overflow
+    }
+    num = num * 10 + digit;
   }
   return pos;
 }
@@ -136,6 +139,14 @@ bool Image::ReadPPM(const hwy::Span<const char>& buf) {
     return false;
   }
   ++pos;
+  if (width == 0 || height == 0) {
+    std::cerr << "Invalid zero dimension\n";
+    return false;
+  }
+  if (width > SIZE_MAX / 3 || width * 3 > SIZE_MAX / height) {
+    std::cerr << "Image dimensions overflow\n";
+    return false;
+  }
   const size_t data_size = width * height * 3;
   if (buf.cend() - pos < static_cast<ptrdiff_t>(data_size)) {
     std::cerr << "Insufficient data remaining\n";

--- a/util/basics.h
+++ b/util/basics.h
@@ -97,7 +97,12 @@ struct Extents2D {
   constexpr Extents2D() : rows(0), cols(0) {}
   constexpr Extents2D(size_t rows, size_t cols) : rows(rows), cols(cols) {}
 
-  size_t Area() const { return rows * cols; }
+  size_t Area() const {
+    if (rows != 0 && cols > SIZE_MAX / rows) {
+      HWY_ABORT("Tensor dimension overflow: rows=%zu cols=%zu", rows, cols);
+    }
+    return rows * cols;
+  }
 
   size_t rows;
   size_t cols;


### PR DESCRIPTION
## Summary

- **Tensor dimension overflow (`util/basics.h`):** `Extents2D::Area()` computes `rows * cols` without checking for `size_t` overflow. When tensor dimensions are deserialized from a model file via `MatPtr::VisitFields()`, attacker-controlled `rows` and `cols` values can silently overflow, causing undersized allocations and subsequent heap buffer overflows. Added an overflow check that aborts if `cols > SIZE_MAX / rows`.

- **PPM image size overflow (`paligemma/image.cc`):** `ReadPPM()` computes `data_size = width * height * 3` without overflow protection. A crafted PPM file with large width/height values can overflow this computation, leading to an undersized `data_` vector and out-of-bounds writes during pixel parsing. Added a two-step overflow check before the multiplication.

- **PPM integer parsing overflow (`paligemma/image.cc`):** `ParseUnsigned()` accumulates decimal digits into a `size_t` without detecting overflow, allowing silently wrapped values to bypass subsequent size checks. Added overflow detection that returns `nullptr` (parse failure) when the accumulated value would exceed `SIZE_MAX`.

## Test plan
- [ ] Verify existing tests still pass (`bazel test //...`)
- [ ] Confirm PPM files with normal dimensions load correctly
- [ ] Confirm malformed PPM with overflow-inducing dimensions is rejected gracefully
- [ ] Confirm model files with overflow-inducing tensor dimensions trigger abort