### PR TITLE
Fix flash_attention_test link error on multi-target SIMD builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,17 @@ set(GEMMA_ENABLE_TESTS OFF CACHE BOOL "Enable Gemma tests")
 if (GEMMA_ENABLE_TESTS)
 
 enable_testing()
+find_package(GTest REQUIRED)
 include(GoogleTest)
+
+# Tests use HWY_IS_TEST=1 with `hwy/foreach_target.h`, which expands the test
+# TU for every attainable SIMD target (including EMU128). libgemma's
+# foreach_target sources (flash_attention.cc, attention.cc, gemma.cc, vit.cc)
+# normally compile only for the baseline+best targets, so tests would fail to
+# link against per-target symbols like N_EMU128::FlashAttention. Build
+# libgemma for all attainable targets when tests are enabled, matching what
+# the tests reference.
+target_compile_definitions(libgemma PRIVATE HWY_IS_TEST=1)
 
 set(GEMMA_TEST_FILES
   compression/compress_test.cc


### PR DESCRIPTION
## Summary
- Build `libgemma` with `HWY_IS_TEST=1` when `GEMMA_ENABLE_TESTS=ON` so its `foreach_target.h` translation units (`flash_attention.cc`, `attention.cc`, `gemma.cc`, `vit.cc`) emit symbols for every attainable SIMD target — including `EMU128`, which `flash_attention_test` references.
- Add `find_package(GTest REQUIRED)` inside the test block. The CMakeLists already uses `GTest::Main`, but the target was only being provided transitively by Highway's vendored gtest. Disabling `HWY_ENABLE_TESTS` (required to avoid test-target name collisions with Highway's own `dot_test`/`image_test`) makes that transitive target disappear; an explicit `find_package` keeps tests buildable in that configuration.

## Root cause
`flash_attention_test.cc` includes `hwy/foreach_target.h` and is compiled with `-DHWY_IS_TEST=1`, so it expands once per attainable SIMD target and references per-target symbols (`gcpp::N_EMU128::FlashAttention`, `gcpp::N_EMU128::DotSoftmaxWeightedSum`, `gcpp::N_EMU128::GetVTileSize`). Those symbols live in `libgemma`'s `flash_attention.cc` / `attention.cc`, which were built **without** `HWY_IS_TEST=1` — so Highway only emitted baseline+best targets (no `EMU128`). Result: `Undefined symbols for architecture arm64: gcpp::N_EMU128::FlashAttention ...`.

## Test plan
- [x] `cmake -B build -DGEMMA_ENABLE_TESTS=ON -DHWY_ENABLE_TESTS=OFF` configures clean
- [x] `cmake --build build --target flash_attention_test` links
- [x] `./build/flash_attention_test` passes 3/3 cases across `NEON_BF16`, `NEON_WITHOUT_AES`, and `EMU128`
- [x] No regressions in `tensor_info_test`, `blob_store_test`, `fields_test`, `compress_test`, `sfp_test`, `nuq_test`, `distortion_test`, `ops_test`, `matmul_test`, `image_test`, `basics_test`, `gemma_batch_bench`
- [x] `./build/gemma` still builds and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
