### PR TITLE
Fix null pointer deref in KVCache::ToPtr() - missing .cache = this

### DIFF
--- a/gemma/kv_cache.h
+++ b/gemma/kv_cache.h
@@ -184,6 +184,7 @@ struct KVCache {
         .kv_cache = kv_cache,
         .k_cache = k_cache,
         .v_cache = v_cache,
+        .cache = this,
     };
   }
 


### PR DESCRIPTION
## Problem

Gemma 2B model crashes with a segfault during the prefill phase on a 6GB VM:

[ Reading prompt ] [ BEGIN PHASE: prefill ]
...............Segmentation fault (core dumped)



## Root Cause

`KVCache::ToPtr()` constructs a `KVCachePtr` but omits the `cache` back-reference field, leaving it as the default `nullptr`. When `attention.cc:183` calls `cache->KOrVDefaultCols()`, it dereferences a null pointer.

The bug was introduced during the tiled KV cache refactoring that added the `cache` field to `KVCachePtr` for accessing `tiled_seq_len`.

## Debugging Process

1. Confirmed the crash is not purely memory-related (reproduced with `seq_len=128, num_threads=1`)
2. Confirmed the crash is not SIMD-specific (reproduced on both SSE2 and AVX3_ZEN4 code paths)
3. Compiled with `-fsanitize=address` and got the exact crash point:

==206353==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
#0  gcpp::KVCache::KOrVDefaultCols() const /gemma/kv_cache.h:97:12
#1  gcpp::N_AVX3_ZEN4::ComputeQKV /gemma/attention.cc:183:44



## Fix

Added the missing `.cache = this` field initialization in `KVCache::ToPtr()`:

```cpp
KVCachePtr ToPtr() {
    return KVCachePtr{
        .kv_cache = kv_cache,
        .k_cache = k_cache,
        .v_cache = v_cache,
        .cache = this,   // ← was missing
    };
}
Verification
The fix was tested on a 6GB VM running Gemma 2B Instruct (SFP-compressed):


./gemma --weights 2.0-2b-it-sfp.sbs --tokenizer tokenizer.spm \
  --prompt "Hello" --max_generated_tokens 30

[ Reading prompt ] .........
Hello! My name is Gemma. How can I help you today?

[ Timing info ] Prefill: 583 ms for 15 prompt tokens
[ Timing info ] Generate: 5653 ms for 19 tokens (3.36 tokens/sec)