### PR TITLE
Add build flag to enable profiler

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,4 @@
 common --enable_bzlmod
+
+# Use global copt so the define also reaches @highway.
+build:profiler --copt=-DPROFILER_ENABLED=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
   target_compile_definitions(hwy PUBLIC HWY_DISABLED_TARGETS=HWY_AVX10_2)
 endif()
 
+option(GEMMA_ENABLE_PROFILER "Enable Highway's profiler (per-zone timings)" OFF)
+if (GEMMA_ENABLE_PROFILER)
+  # PUBLIC: reaches Highway's profiler.cc and all targets linking hwy.
+  target_compile_definitions(hwy PUBLIC PROFILER_ENABLED=1)
+endif()
+
 ## Note: absl needs to be installed by sentencepiece. This will only happen if
 ## cmake is invoked with -DSPM_ENABLE_SHARED=OFF and -DSPM_ABSL_PROVIDER=module
 FetchContent_Declare(sentencepiece GIT_REPOSITORY https://github.com/google/sentencepiece GIT_TAG 9045b2f60fa2b323dfac0eaef8fc17565036f9f9 EXCLUDE_FROM_ALL)

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -175,6 +175,19 @@ the Abseil library. `bazel/sentencepiece.patch` changes the code to support
 Abseil as a standalone dependency without third_party/ prefixes, similar to the
 transforms we apply to Gemma via Copybara.
 
+## Profiling
+
+Gemma.cpp is instrumented with Highway's profiler (`hwy/profiler.h`). Zones
+cover prefill, attention, MatMul and weight loading (see `util/zones.h`).
+Profiling is disabled by default and can be enabled at build time:
+
+*   CMake: `cmake -B build -DGEMMA_ENABLE_PROFILER=ON ...`
+*   Bazel: add `--config=profiler` to the build command.
+
+Benchmarks such as `gemma_batch_bench` and `bench_matmul` print per-zone call
+counts and self-times via `PROFILER_PRINT_RESULTS()`. For performance
+measurements we recommend `gemma_batch_bench`.
+
 ## Debugging
 
 At the first sign of incorrect or unexpected results, we recommend running with


### PR DESCRIPTION
PR to float idea of an easy way to enable profiler via build flags and document how to use.

`bench_matmul` with `--config=profiler`
<img width="1219" height="333" alt="image" src="https://github.com/user-attachments/assets/e70b0fb1-d4c2-4e43-92e9-4f88026692ca" />
