### PR TITLE
Use ModelConfig for dense RoPE theta

### DIFF
--- a/gemma/activations.h
+++ b/gemma/activations.h
@@ -123,13 +123,13 @@ struct AttentionActivations {
         v_tile_vec(MatFactory("v_tile_vec", batch_size * layer_config.kv_heads,
                               KVCache::kTileSize * max_qkv_dim, allocator)),
 
-        inv_timescale(
-            CreateInvTimescale(allocator, layer_config.qkv_dim,
-                               layer_config.post_qk == PostQKType::HalfRope)),
-        inv_timescale_global(
-            CreateInvTimescale(allocator, max_qkv_dim,
-                               layer_config.post_qk == PostQKType::HalfRope,
-                               1000000.0, config.partial_rotary_factor)) {
+        inv_timescale(CreateInvTimescale(
+            allocator, layer_config.qkv_dim,
+            layer_config.post_qk == PostQKType::HalfRope, config.rope_theta)),
+        inv_timescale_global(CreateInvTimescale(
+            allocator, max_qkv_dim,
+            layer_config.post_qk == PostQKType::HalfRope,
+            config.global_rope_theta, config.partial_rotary_factor)) {
     // Batch size can be 0 in experimental code so do not assert.
     if (batch_size == 0) {
       static std::atomic_flag warned = ATOMIC_FLAG_INIT;
@@ -456,7 +456,8 @@ struct Activations {
                 ? CreateInvTimescale(ctx.allocator,
                                      config.encoder_layer_configs[0].qkv_dim,
                                      config.encoder_layer_configs[0].post_qk ==
-                                         PostQKType::HalfRope)
+                                         PostQKType::HalfRope,
+                                     config.rope_theta)
                 : MatStorageT<float>()),
 
         max_workers(ctx.pools.MaxWorkers()),

--- a/gemma/configs.cc
+++ b/gemma/configs.cc
@@ -38,6 +38,8 @@ static ModelConfig ConfigNoSSM() {
   config.scale_base_names = {"att_ein",    "qkv_ein",      "gr_lin_x_w",
                              "gr_lin_y_w", "gr_lin_out_w", "gr_gate_w",
                              "gating_ein", "linear_w"};
+  config.rope_theta = 10000.0f;
+  config.global_rope_theta = 1000000.0f;
   return config;
 }
 
@@ -47,6 +49,8 @@ static ModelConfig ConfigBaseGemmaV2() {
   config.final_cap = 30.0f;
   config.eos_id = 1;
   config.secondary_eos_id = 107;
+  config.rope_theta = 10000.0f;
+  config.global_rope_theta = 10000.0f;
   return config;
 }
 
@@ -217,6 +221,8 @@ static ModelConfig ConfigBaseGemmaV3() {
   config.final_cap = 0.0f;
   config.eos_id = 1;
   config.secondary_eos_id = 106;
+  config.rope_theta = 10000.0f;
+  config.global_rope_theta = 1000000.0f;
   return config;
 }
 
@@ -423,6 +429,7 @@ static ModelConfig ConfigGemma3_270M() {
   config.display_name = "Gemma3_270M";
   config.model = Model::GEMMA3_270M;
   config.wrapping = PromptWrapping::GEMMA_IT;
+  config.global_rope_theta = 10000.0f;
   config.model_dim = 640;
   config.vocab_size = kGemmaV3VocabSize;  // new vocab size / tokenizer
   config.max_seq_len = 32 * 1024;
@@ -444,6 +451,8 @@ static ModelConfig ConfigBaseGemmaV4() {
   config.eos_id = 1;
   config.secondary_eos_id = 106;
   config.vocab_size = 262208;
+  config.rope_theta = 10000.0f;
+  config.global_rope_theta = 1000000.0f;
   return config;
 }
 
@@ -670,6 +679,7 @@ static ModelConfig ConfigDeepSeek4_Flash() {
   config.attention_window_sizes = FixedAttentionWindowSizes<43>(128);
 
   config.rope_theta = 10000.0f;
+  config.global_rope_theta = 10000.0f;
   config.compress_rope_theta = 160000.0f;
   config.yarn_orig_seq_len = 65536;
   config.yarn_factor = 16.0f;
@@ -700,6 +710,8 @@ static ModelConfig ConfigBaseT5Gemma() {
   config.final_cap = 30.0f;
   config.eos_id = 1;
   config.secondary_eos_id = 107;
+  config.rope_theta = 10000.0f;
+  config.global_rope_theta = 10000.0f;
   return config;
 }
 
@@ -774,6 +786,8 @@ static ModelConfig ConfigQwen3_600M() {
   config.display_name = "Qwen3_0.6B";
   config.model = Model::QWEN3_600M;
   config.wrapping = PromptWrapping::GEMMA_IT;
+  config.rope_theta = 1000000.0f;
+  config.global_rope_theta = 1000000.0f;
   config.model_dim = 1024;
 
   LayerConfig layer_config =
@@ -792,6 +806,8 @@ static ModelConfig ConfigQwen3_2B() {
   config.display_name = "Qwen3_1.7B";
   config.model = Model::QWEN3_2B;
   config.wrapping = PromptWrapping::GEMMA_IT;
+  config.rope_theta = 1000000.0f;
+  config.global_rope_theta = 1000000.0f;
   config.model_dim = 2048;
 
   LayerConfig layer_config =
@@ -810,6 +826,8 @@ static ModelConfig ConfigQwen3_4B() {
   config.display_name = "Qwen3_4B";
   config.model = Model::QWEN3_4B;
   config.wrapping = PromptWrapping::GEMMA_IT;
+  config.rope_theta = 1000000.0f;
+  config.global_rope_theta = 1000000.0f;
   config.model_dim = 2560;
 
   LayerConfig layer_config =

--- a/gemma/configs.h
+++ b/gemma/configs.h
@@ -673,6 +673,8 @@ struct ModelConfig : public IFields {
       visitor(decoder_attention_window_sizes);
     }
 
+    visitor(global_rope_theta);
+
     // Append new fields here, then update `python/configs.cc`.
   }
 
@@ -850,6 +852,9 @@ struct ModelConfig : public IFields {
 
   // RoPE base frequency for the raw/sliding-window attention path.
   float rope_theta = 10000.0f;
+  // RoPE base frequency for global attention layers. Appended to VisitFields
+  // for serialization compatibility.
+  float global_rope_theta = 1000000.0f;
   // DeepSeek V4: separate base frequency for compressed-attention layers
   // (query, window keys and compressed keys all use this on those layers).
   // 0 = same as rope_theta.

--- a/gemma/gemma.cc
+++ b/gemma/gemma.cc
@@ -988,9 +988,9 @@ static void T5GemmaGenerateT(const ModelConfig& config,
       "t5_d_kv", qbatch.Size(),
       2 * layer_config.kv_heads * layer_config.qkv_dim, env.ctx.allocator));
   decoder_kv.AllocateAndAttachRowPtrs(env.row_ptrs);
-  MatStorageT<float> inv_timescale =
-      CreateInvTimescale(env.ctx.allocator, layer_config.qkv_dim,
-                         layer_config.post_qk == PostQKType::HalfRope);
+  MatStorageT<float> inv_timescale = CreateInvTimescale(
+      env.ctx.allocator, layer_config.qkv_dim,
+      layer_config.post_qk == PostQKType::HalfRope, config.rope_theta);
   auto logits_chunk_row_ptrs = hwy::AllocateAligned<uint8_t*>(qbatch.Size());
   std::vector<int> greedy_tokens(qbatch.Size());
   std::vector<float> greedy_logits(qbatch.Size());

--- a/ops/ops.h
+++ b/ops/ops.h
@@ -27,7 +27,7 @@ namespace gcpp {
 
 static inline HWY_MAYBE_UNUSED MatStorageT<float> CreateInvTimescale(
     const Allocator& allocator, size_t qkv_dim, bool half_rope,
-    double base_frequency = 10000.0, float partial_rotary_factor = 1.0f) {
+    double base_frequency, float partial_rotary_factor = 1.0f) {
   const size_t rope_dim = half_rope ? qkv_dim / 2 : qkv_dim;
   const size_t total_entries = rope_dim / 2;
   const size_t active_entries =

--- a/ops/ops_test.cc
+++ b/ops/ops_test.cc
@@ -603,7 +603,8 @@ void TestRopeAndMulBy() {
   MatStorageT<float> kactual2("kactual2", dim_qkv, ctx.allocator);
   MatStorageT<float> inv_timescale = CreateInvTimescale(
       ctx.allocator, config.layer_configs[0].qkv_dim,
-      config.layer_configs[0].post_qk == PostQKType::HalfRope);
+      config.layer_configs[0].post_qk == PostQKType::HalfRope,
+      config.rope_theta);
   // Assert VectorizedRope computation is same as regular rope at different pos.
   for (size_t pos = 1; pos < 500; pos++) {
     // Rope'd Q embeddings with query scale

--- a/python/configs.cc
+++ b/python/configs.cc
@@ -229,6 +229,7 @@ PYBIND11_MODULE(configs, py_module) {
                      &gcpp::ModelConfig::partial_rotary_factor)
       .def_readwrite("hc_mult", &gcpp::ModelConfig::hc_mult)
       .def_readwrite("rope_theta", &gcpp::ModelConfig::rope_theta)
+      .def_readwrite("global_rope_theta", &gcpp::ModelConfig::global_rope_theta)
       .def_readwrite("compress_rope_theta",
                      &gcpp::ModelConfig::compress_rope_theta)
       .def_readwrite("yarn_orig_seq_len", &gcpp::ModelConfig::yarn_orig_seq_len)


### PR DESCRIPTION
## Summary

- use ModelConfig.rope_theta for local dense-attention RoPE
- add a serialized global_rope_theta field and expose it through Python bindings
- set local and global theta explicitly for each model family
- remove the default theta from CreateInvTimescale while retaining use_global_timescale

Fixes #986

## Testing

- ops_test: 38 tests passed
- configs_test: 7 tests passed