### PR TITLE
Avoid repeated reallocation of the TopK buffer

### DIFF
--- a/ops/ops-inl.h
+++ b/ops/ops-inl.h
@@ -1578,12 +1578,22 @@ HWY_NOINLINE HWY_MAYBE_UNUSED std::vector<TokenAndProb> TopK(
     Logits logits, size_t k, TAcceptToken& accept_token) {
   HWY_ASSERT(k != 0);
   HWY_ASSERT(k <= logits.size());
+  const int32_t num_logits = static_cast<int32_t>(logits.size());
+  // `logits.size()` is the vocabulary size (256K for Gemma 3), so growing the
+  // vector on demand would reallocate and copy about a dozen times per call.
   std::vector<double> packed_token_probs;
-  for (int32_t i = 0; i < static_cast<int32_t>(logits.size()); ++i) {
-    if (accept_token && !accept_token(i, logits[i])) {
-      continue;
+  packed_token_probs.reserve(logits.size());
+  // Hoisting the (usually empty) `accept_token` check out of the loop keeps the
+  // common case a straight-line pack-and-append.
+  if (accept_token) {
+    for (int32_t i = 0; i < num_logits; ++i) {
+      if (!accept_token(i, logits[i])) continue;
+      packed_token_probs.push_back(PackTokenAndProb(i, logits[i]));
     }
-    packed_token_probs.push_back(PackTokenAndProb(i, logits[i]));
+  } else {
+    for (int32_t i = 0; i < num_logits; ++i) {
+      packed_token_probs.push_back(PackTokenAndProb(i, logits[i]));
+    }
   }
 
   hwy::VQSelect(packed_token_probs.data(), packed_token_probs.size(), k,

--- a/ops/ops_test.cc
+++ b/ops/ops_test.cc
@@ -884,6 +884,36 @@ void TestSampleTopK() {
   }
 }
 
+// `TopK` must return the k largest logits in descending order, with and
+// without an `accept_token` filter. `kSize` exceeds the initial capacity of the
+// vector that `TopK` fills, so this also covers the reserved-capacity path.
+void TestTopK() {
+  const size_t kSize = 300;
+  std::vector<float> logits_vec(kSize);
+  std::iota(logits_vec.begin(), logits_vec.end(), 0.0f);
+  Logits logits(logits_vec.data(), kSize);
+
+  // Without a filter, the top-k are the last k indices, largest first.
+  std::function<bool(int, float)> accept_token;
+  std::vector<TokenAndProb> top = TopK(logits, /*k=*/5, accept_token);
+  ASSERT_EQ(top.size(), size_t{5});
+  for (size_t i = 0; i < top.size(); ++i) {
+    const size_t expected = kSize - 1 - i;
+    EXPECT_EQ(top[i].token, static_cast<int>(expected));
+    EXPECT_EQ(top[i].prob, logits[expected]);
+  }
+
+  // With a filter, only even tokens are eligible.
+  accept_token = [](int i, float) { return i % 2 == 0; };
+  top = TopK(logits, /*k=*/5, accept_token);
+  ASSERT_EQ(top.size(), size_t{5});
+  for (size_t i = 0; i < top.size(); ++i) {
+    const size_t expected = kSize - 2 - 2 * i;
+    EXPECT_EQ(top[i].token, static_cast<int>(expected));
+    EXPECT_EQ(top[i].prob, logits[expected]);
+  }
+}
+
 void TestPackTokenAndProb() {
   double packed1 = PackTokenAndProb(10, 0.96f);
   TokenAndProb unpacked1 = UnpackTokenAndProb(packed1);
@@ -922,6 +952,7 @@ HWY_EXPORT_AND_TEST_P(OpsTest, TestAllRMSNormInplace);
 HWY_EXPORT_AND_TEST_P(OpsTest, TestAllLayerNorm);
 HWY_EXPORT_AND_TEST_P(OpsTest, TestLayerNormSimple);
 HWY_EXPORT_AND_TEST_P(OpsTest, TestSampleTopK);
+HWY_EXPORT_AND_TEST_P(OpsTest, TestTopK);
 HWY_EXPORT_AND_TEST_P(OpsTest, TestPackTokenAndProb);
 HWY_AFTER_TEST();
 


### PR DESCRIPTION
## Summary

`TopK` fills a `std::vector<double>` with one packed entry per logit but starts from an empty vector. `logits.size()` is the vocabulary size, so for Gemma 3's 256K vocabulary libstdc++ reallocates 19 times and copies 2.1 MB before the buffer reaches its final size. This runs once per sampled token via `FusedSoftmaxAndSampleTopK`, which `ChooseSampleFunc` selects whenever `top_k` is greater than 1 or an `accept_token` filter is set.

This reserves the full size up front and hoists the `accept_token` test out of the loop, so the common case (no constrained decoding) is a straight-line pack-and-append rather than a `std::function` test per logit. Peak transient memory also falls, because the final doubling no longer holds the old and new buffers at the same time.

Sampling results are unchanged: the same entries are appended in the same order, so the subsequent `VQSelect`/`VQSort` see identical input.

## Performance

Deterministic reduction, for a 256K vocabulary:

- Allocations per call: 19 -> 1
- Bytes copied by reallocation: 2.10 MB -> 0
- Peak transient buffer: 3 MB -> 2 MB

Wall time, interleaved baseline/patched runs, best of 30 calls (300 for the small cases), median of three runs:

| Case | Baseline | Patched | Change |
|------|----------|---------|--------|
| vocab 262144, k=50 | 366.7 us | 284.0 us | -22.6% |
| vocab 32768, k=50 | 43.4 us | 33.3 us | -23.3% |
| vocab 256, k=3 | 0.63 us | 0.51 us | -19% |
| vocab 262144, k=50, accept_token | 485.2 us | 461.4 us | neutral (within noise) |

The `accept_token` case is the control: it keeps the per-element filter call, which dominates, so it is unaffected.

Environment:
- CPU: Intel Core i9-13905H
- Compiler: GCC 14.2.0
- Build: CMake Release, Ninja, -O3 -DNDEBUG
- Highway target: AVX2 (best attainable on this CPU)
- Repetitions: best of 30 per run, three interleaved runs, pinned with taskset

This is a sampling-path improvement, not an end-to-end decode speedup; on a memory-bound decode step the saving is small next to the output-head MatMul.

## Testing

- New `TestTopK` covers the filtered and unfiltered paths, asserting exact tokens and probabilities. Its size exceeds the vector's initial capacity, so it exercises the reserved-capacity path.
- `ops_test` passes 40/40 across AVX2 and EMU128; `compress_test` and `sfp_test` unaffected.
- `ops_test.cc` built with `-fsanitize=address` and run with `detect_leaks=1`: 40/40 pass, no errors and no leaks.

## Notes

Only x86-64 (AVX2) was measured; ARM was not benchmarked. The change is allocation behaviour rather than SIMD, so it should carry over, but I have not verified that.