### PR TITLE
Block FP32 vision attention value accumulation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -553,6 +553,7 @@ cc_library(
     },
     textual_hdrs = [
         "gemma/gemma-inl.h",
+        "gemma/vit_attention-inl.h",
     ],
     deps = [
         ":basics",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SOURCES
   gemma/tokenizer.h
   gemma/vit.cc
   gemma/vit.h
+  gemma/vit_attention-inl.h
   gemma/weights.cc
   gemma/weights.h
   io/blob_store.cc

--- a/gemma/vit.cc
+++ b/gemma/vit.cc
@@ -42,6 +42,7 @@
 #include "hwy/highway.h"
 // After highway.h
 #include "gemma/gemma-inl.h"
+#include "gemma/vit_attention-inl.h"
 #include "ops/ops-inl.h"
 
 HWY_BEFORE_NAMESPACE();
@@ -68,7 +69,7 @@ class VitAttention {
                layer_.vit.qkv_einsum_b.PackedScale1(), env_, qkv);
   }
 
-  // TODO(philculliton): transition fully to MatMul.
+  // QK uses the general matrix kernel; PV keeps FP32 values/probabilities.
   HWY_NOINLINE void DotSoftmaxWeightedSumMatrix() {
     const size_t qkv_dim = layer_config_.qkv_dim;
     const size_t heads = layer_config_.heads;
@@ -83,11 +84,10 @@ class VitAttention {
                          env_.ctx.allocator, MatPadding::kPacked);
     MatStorageT<float> K("K2", Extents2D(seq_len, qkv_dim), env_.ctx.allocator,
                          MatPadding::kPacked);
+    MatStorageT<float> V("V2", Extents2D(seq_len, qkv_dim), env_.ctx.allocator,
+                         MatPadding::kPacked);
     MatStorageT<float> C("C2", Extents2D(num_tokens_, seq_len),
                          env_.ctx.allocator, MatPadding::kPacked);
-
-    // Initialize att_out to zero prior to head loop.
-    ZeroInit(activations_.attention.att_out);
 
     for (size_t head = 0; head < heads; ++head) {
       pool_.Run(0, num_tokens_, caller1_,
@@ -107,6 +107,8 @@ class VitAttention {
             float* HWY_RESTRICT k = activations_.attention.q.Row(seq_idx) +
                                     head * 3 * qkv_dim + qkv_dim;
             hwy::CopyBytes(k, K.Row(seq_idx), qkv_dim * sizeof(float));
+            hwy::CopyBytes(k + qkv_dim, V.Row(seq_idx),
+                           qkv_dim * sizeof(float));
           });
 
       // this produces C, a (num_tokens_, seq_len) matrix of dot products
@@ -117,15 +119,10 @@ class VitAttention {
                     HWY_ATTR { Softmax(C.RowSpan(task), env_.ctx, worker); });
 
       pool_.Run(
-          0, num_tokens_, caller4_, [&](uint64_t task, size_t worker) HWY_ATTR {
-            size_t token = task;
-            float* HWY_RESTRICT att_out =
-                activations_.attention.att_out.Row(token) + head * qkv_dim;
-            for (size_t i = 0; i < seq_len; ++i) {
-              float* HWY_RESTRICT v = activations_.attention.q.Row(i) +
-                                      head * 3 * qkv_dim + 2 * qkv_dim;
-              MulByConstAndAdd(C.Row(token)[i], v, att_out, qkv_dim);
-            }
+          0, hwy::DivCeil(num_tokens_, size_t{4}), caller4_,
+          [&](uint64_t task, size_t /*worker*/) HWY_ATTR {
+            VitAttentionValueProduct(C, V, activations_.attention.att_out,
+                                     task * 4, head * qkv_dim);
           });
     }
   }

--- a/gemma/vit_attention-inl.h
+++ b/gemma/vit_attention-inl.h
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef THIRD_PARTY_GEMMA_CPP_GEMMA_VIT_ATTENTION_INL_H_
+#define THIRD_PARTY_GEMMA_CPP_GEMMA_VIT_ATTENTION_INL_H_
+#include <stddef.h>
+
+#include "util/mat.h"
+#endif
+
+#if defined(GEMMA_VIT_ATTENTION_TOGGLE) == defined(HWY_TARGET_TOGGLE)
+#ifdef GEMMA_VIT_ATTENTION_TOGGLE
+#undef GEMMA_VIT_ATTENTION_TOGGLE
+#else
+#define GEMMA_VIT_ATTENTION_TOGGLE
+#endif
+
+#include "hwy/highway.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace gcpp {
+namespace HWY_NAMESPACE {
+
+// Four query rows share each V load. Two vectors per row leave room for the
+// weights and V in AVX2's 16 registers. Each output retains the original
+// increasing-source-position FP32 MulAdd order; there is no BF16 conversion.
+template <size_t kRows, bool kTwoVectors, bool kTail>
+HWY_INLINE void VitValueTile(const MatPtrT<float>& probabilities,
+                             const MatPtrT<float>& values,
+                             MatPtrT<float>& output, size_t row, size_t col,
+                             size_t output_offset) {
+  namespace hn = hwy::HWY_NAMESPACE;
+  const hn::ScalableTag<float> d;
+  const size_t lanes = hn::Lanes(d);
+  const size_t count = kTail ? values.Cols() - col : lanes;
+  auto a0 = hn::Zero(d), a1 = a0, a2 = a0, a3 = a0;
+  auto b0 = a0, b1 = a0, b2 = a0, b3 = a0;
+  const float* HWY_RESTRICT p0 = probabilities.Row(row);
+  const float* HWY_RESTRICT p1 = kRows == 4 ? probabilities.Row(row + 1) : p0;
+  const float* HWY_RESTRICT p2 = kRows == 4 ? probabilities.Row(row + 2) : p0;
+  const float* HWY_RESTRICT p3 = kRows == 4 ? probabilities.Row(row + 3) : p0;
+  for (size_t i = 0; i < values.Rows(); ++i) {
+    const float* HWY_RESTRICT v = values.Row(i) + col;
+    const auto v0 = kTail ? hn::LoadN(d, v, count) : hn::LoadU(d, v);
+    const auto w0 = hn::Set(d, p0[i]);
+    a0 = hn::MulAdd(w0, v0, a0);
+    if constexpr (kRows == 4) {
+      a1 = hn::MulAdd(hn::Set(d, p1[i]), v0, a1);
+      a2 = hn::MulAdd(hn::Set(d, p2[i]), v0, a2);
+      a3 = hn::MulAdd(hn::Set(d, p3[i]), v0, a3);
+    }
+    if constexpr (kTwoVectors) {
+      const auto v1 = hn::LoadU(d, v + lanes);
+      b0 = hn::MulAdd(w0, v1, b0);
+      if constexpr (kRows == 4) {
+        b1 = hn::MulAdd(hn::Set(d, p1[i]), v1, b1);
+        b2 = hn::MulAdd(hn::Set(d, p2[i]), v1, b2);
+        b3 = hn::MulAdd(hn::Set(d, p3[i]), v1, b3);
+      }
+    }
+  }
+  float* out0 = output.Row(row) + output_offset + col;
+  if constexpr (kTail)
+    hn::StoreN(a0, d, out0, count);
+  else
+    hn::StoreU(a0, d, out0);
+  if constexpr (kTwoVectors) hn::StoreU(b0, d, out0 + lanes);
+  if constexpr (kRows == 4) {
+    float* out1 = output.Row(row + 1) + output_offset + col;
+    float* out2 = output.Row(row + 2) + output_offset + col;
+    float* out3 = output.Row(row + 3) + output_offset + col;
+    if constexpr (kTail) {
+      hn::StoreN(a1, d, out1, count);
+      hn::StoreN(a2, d, out2, count);
+      hn::StoreN(a3, d, out3, count);
+    } else {
+      hn::StoreU(a1, d, out1);
+      hn::StoreU(a2, d, out2);
+      hn::StoreU(a3, d, out3);
+    }
+    if constexpr (kTwoVectors) {
+      hn::StoreU(b1, d, out1 + lanes);
+      hn::StoreU(b2, d, out2 + lanes);
+      hn::StoreU(b3, d, out3 + lanes);
+    }
+  }
+}
+
+template <size_t kRows>
+HWY_INLINE void VitValueRows(const MatPtrT<float>& probabilities,
+                             const MatPtrT<float>& values,
+                             MatPtrT<float>& output, size_t row,
+                             size_t output_offset) {
+  const size_t lanes =
+      hwy::HWY_NAMESPACE::Lanes(hwy::HWY_NAMESPACE::ScalableTag<float>());
+  size_t col = 0;
+  for (; col + 2 * lanes <= values.Cols(); col += 2 * lanes) {
+    VitValueTile<kRows, true, false>(probabilities, values, output, row, col,
+                                     output_offset);
+  }
+  if (col + lanes <= values.Cols()) {
+    VitValueTile<kRows, false, false>(probabilities, values, output, row, col,
+                                      output_offset);
+    col += lanes;
+  }
+  if (col < values.Cols()) {
+    VitValueTile<kRows, false, true>(probabilities, values, output, row, col,
+                                     output_offset);
+  }
+}
+
+// One task owns up to four output rows. Output can contain adjacent heads;
+// only this head's columns are written, including for partial SIMD vectors.
+HWY_INLINE void VitAttentionValueProduct(const MatPtrT<float>& probabilities,
+                                         const MatPtrT<float>& values,
+                                         MatPtrT<float>& output, size_t row,
+                                         size_t output_offset) {
+  HWY_DASSERT(probabilities.Cols() == values.Rows());
+  HWY_DASSERT(probabilities.Rows() <= output.Rows());
+  HWY_DASSERT(output_offset + values.Cols() <= output.Cols());
+  if (row + 4 <= probabilities.Rows()) {
+    VitValueRows<4>(probabilities, values, output, row, output_offset);
+  } else {
+    for (; row < probabilities.Rows(); ++row) {
+      VitValueRows<1>(probabilities, values, output, row, output_offset);
+    }
+  }
+}
+
+}  // namespace HWY_NAMESPACE
+}  // namespace gcpp
+HWY_AFTER_NAMESPACE();
+#endif  // GEMMA_VIT_ATTENTION_TOGGLE


### PR DESCRIPTION
Gemma 3 vision attention on `main` calls `MulByConstAndAdd` for every query/source pair, repeatedly loading V and updating the output vector. This change packs V per head and computes four query rows together, keeping FP32 accumulators in SIMD registers and sharing V loads.

Fixes https://github.com/google/gemma.cpp/issues/1018

**Scope and implementation**

- Targets `dev`. The current patch and measurements were developed against `main` at `3ed403e`; `dev` has replaced this loop with FlashAttention, so integration requires a port and fresh validation. The measurements below do not establish a speedup over `dev`.
- Preserves the source-position accumulation order, supports row/vector tails, and uses the existing thread pool.
- Adds 1.125 MiB of scratch for 4,096 patches × 72 FP32 values, reused across heads.
- Includes only the kernel, its integration, and required CMake/Bazel header entries.

**Measurement setup**

- CPU: Intel Core i5-12400F; six pinned physical CPU workers, AVX2, spin waits enabled.
- Platform/build: Linux x86-64, GCC 13.3.0, Release (`-O3 -DNDEBUG`).
- Model: Gemma 3 4B, `4b-it-sfp-padded.sbs` weights.
- Input: repository `paligemma/testdata/image.ppm`, resized to 896 × 896 (4,096 patches).
- Three serial A/B pairs, alternating order: before/after, after/before, before/after.
- Each process performed one warmup encoding and one measured encoding, with a common baseline-calibrated MatMul plan to isolate this change from autotuning differences.
- Both local A/B builds included the same pre-existing KV-cache changes; the baseline was not a pristine `main` build. Those changes are excluded from this PR.

**Image-encoder latency**

| Pair | Before | After |
|---|---:|---:|
| 1 | 38.019 s | 19.455 s |
| 2 | 38.899 s | 19.985 s |
| 3 | 38.887 s | 19.703 s |
| Median | **38.887 s** | **19.703 s** |

**1.97× faster image encoding; 49.3% lower latency (19.18 s saved per image).**
Timing excludes model/image loading, resizing, language-model prefill, text generation, and output-file writes. Each pass recomputes the image embeddings; there is no previous-image cache.

**Validation**

- Complete image embeddings were byte-identical in all three pairs: 256 × 2,560 FP32 values per run. Generated text was not compared.
- Local kernel comparisons passed 182 cases per target on AVX2 and EMU128, covering tails, unaligned/padded data, adjacent output heads, and varied values.
- All 12 related regression tests passed; all four kernel tests also passed AddressSanitizer/UndefinedBehaviorSanitizer with leak detection (kernel/tests instrumented).
- CLI and API server builds passed. The isolated PR source also compiled against clean `main` headers, and its four kernel tests passed.
- Tests, benchmarks, reports, and artifacts remain local and are not committed.

Measurements cover one image/model on this CPU with unlocked clocks; speed and numerical equivalence beyond the tested cases are not established.
