### PR TITLE
Use the current SIMD target's width for the transposed KV cache

### DIFF
--- a/gemma/attention.cc
+++ b/gemma/attention.cc
@@ -60,7 +60,7 @@ void TransposeKVCacheRow(const KV_t* HWY_RESTRICT kv, KV_t* HWY_RESTRICT k,
   // This is inefficient, as the writes are scattered over cache lines, but it
   // is a tiny fraction of the overall computation, and it is linear in the
   // token length.
-  const size_t kFloatsPerTile = 2 * FloatsPerVector();
+  const size_t kFloatsPerTile = 2 * hn::Lanes(hn::ScalableTag<float>());
   const size_t kRoundedQkvDim = hwy::RoundUpTo(qkv_dim, kMaxBF16PerVector);
   for (size_t i = 0; i < qkv_dim; i += 2) {
     k[i * kFloatsPerTile] = kv[i];
@@ -94,7 +94,7 @@ void TransposeKVCacheRow(const KV_t* HWY_RESTRICT kv, KV_t* HWY_RESTRICT k,
 
 void TransposeKVCacheRow_KEqV(const KV_t* HWY_RESTRICT kv, KV_t* HWY_RESTRICT k,
                               KV_t* HWY_RESTRICT v, size_t qkv_dim) {
-  const size_t kFloatsPerTile = 2 * FloatsPerVector();
+  const size_t kFloatsPerTile = 2 * hn::Lanes(hn::ScalableTag<float>());
   const size_t kRoundedQkvDim = hwy::RoundUpTo(qkv_dim, kMaxBF16PerVector);
   for (size_t i = 0; i < qkv_dim; i += 2) {
     k[i * kFloatsPerTile] = kv[i];
@@ -130,7 +130,7 @@ void TransposeKVCacheRow_KEqV(const KV_t* HWY_RESTRICT kv, KV_t* HWY_RESTRICT k,
 // positions.
 void TransposeOOBKVCacheRow(KV_t* HWY_RESTRICT k, KV_t* HWY_RESTRICT v,
                             size_t qkv_dim) {
-  const size_t kFloatsPerTile = 2 * FloatsPerVector();
+  const size_t kFloatsPerTile = 2 * hn::Lanes(hn::ScalableTag<float>());
   const size_t kRoundedQkvDim = hwy::RoundUpTo(qkv_dim, kMaxBF16PerVector);
   for (size_t i = 0; i < kRoundedQkvDim; i += 2) {
     k[i * kFloatsPerTile] = hwy::ConvertScalarTo<KV_t>(0.0f);
@@ -230,13 +230,13 @@ static HWY_INLINE void ComputeQKV(size_t num_tokens, const size_t layer_idx,
   CallMatMul(activations.pre_att_rms_out, layer.qkv_einsum_w2,
              /*add=*/nullptr, env, kv_rows);
 
+  const size_t kFloatsPerVector = hn::Lanes(hn::ScalableTag<float>());
   for (size_t qi = 0; qi < qbatch.Size(); ++qi) {
-    MaybeReshapeCache(qbatch.KV(qi).cache->KOrVDefaultCols(),
+    MaybeReshapeCache(qbatch.KV(qi).cache->KOrVDefaultCols(), kFloatsPerVector,
                       qbatch.KV(qi).k_cache);
-    MaybeReshapeCache(qbatch.KV(qi).cache->KOrVDefaultCols(),
+    MaybeReshapeCache(qbatch.KV(qi).cache->KOrVDefaultCols(), kFloatsPerVector,
                       qbatch.KV(qi).v_cache);
   }
-  const size_t kFloatsPerVector = FloatsPerVector();
   const size_t kRoundedTokens =
       hwy::RoundUpTo(num_tokens, 2 * kFloatsPerVector);
   const size_t kRoundedNumInterleaved =

--- a/gemma/attention.h
+++ b/gemma/attention.h
@@ -27,12 +27,8 @@
 #include "gemma/weights.h"   // LayerWeightsPtrs
 #include "ops/matmul.h"
 #include "hwy/highway.h"     // HWY_VISIT_TARGETS
-#include "hwy/per_target.h"  // VectorBytes
 
 namespace gcpp {
-
-// Returns the number of floats per vector (aka NF).
-inline size_t FloatsPerVector() { return hwy::VectorBytes() / sizeof(float); }
 
 // The attention window usually starts at 0 unless `pos` is larger than
 // the attention window size, then it is `pos` - window_size + 1.
@@ -44,10 +40,12 @@ inline size_t StartPos(size_t pos, const ModelConfig& config,
 
 // The k-cache and v-cache are setup without knowing NF. So if it hasn't been
 // done already, reshape it to take NF into account. Must be called before
-// FlashAttention.
-inline void MaybeReshapeCache(const size_t default_cols, MatPtrT<KV_t>& cache) {
+// FlashAttention. `nf` must be the number of floats per vector of the SIMD
+// target that runs it, i.e. `hn::Lanes(hn::ScalableTag<float>())`.
+inline void MaybeReshapeCache(const size_t default_cols, const size_t nf,
+                              MatPtrT<KV_t>& cache) {
   if (default_cols == cache.Cols()) {
-    cache.ReshapePackedRowsToCols(2 * FloatsPerVector());
+    cache.ReshapePackedRowsToCols(2 * nf);
   }
 }
 

--- a/gemma/flash_attention_test.cc
+++ b/gemma/flash_attention_test.cc
@@ -355,14 +355,14 @@ void TestFlashAttention(size_t target_parallelism,
   const size_t kHeadGroups = layer_config.heads / layer_config.kv_heads;
   const size_t seq_len =
       static_cast<size_t>(att_activations.div_seq_len.GetDivisor());
-  MaybeReshapeCache(qbatch.KV(0).cache->KOrVDefaultCols(),
-                    qbatch.KV(0).k_cache);
-  MaybeReshapeCache(qbatch.KV(0).cache->KOrVDefaultCols(),
-                    qbatch.KV(0).v_cache);
-  auto& kvc = qbatch.KV(0).kv_cache;
   using DF = hn::ScalableTag<float>;
   const DF df;
   const size_t kNF = hn::Lanes(df);
+  MaybeReshapeCache(qbatch.KV(0).cache->KOrVDefaultCols(), kNF,
+                    qbatch.KV(0).k_cache);
+  MaybeReshapeCache(qbatch.KV(0).cache->KOrVDefaultCols(), kNF,
+                    qbatch.KV(0).v_cache);
+  auto& kvc = qbatch.KV(0).kv_cache;
   const size_t kFloatsPerTile = 2 * kNF;
   for (size_t h = 0; h < layer_config.heads; ++h) {
     // Make strided views into the kv cache for

--- a/gemma/vit.cc
+++ b/gemma/vit.cc
@@ -214,7 +214,7 @@ class VitAttention {
     const size_t qkv_dim = layer_config_.qkv_dim;
     const size_t heads = layer_config_.heads;
     HWY_ASSERT_M(heads == layer_config_.kv_heads, "Vit expects MHA");
-    const size_t kNF = FloatsPerVector();
+    const size_t kNF = hn::Lanes(hn::ScalableTag<float>());
     const size_t kRoundedKVDim = hwy::RoundUpTo(qkv_dim, 2 * kNF);
     auto& attn = activations_.attention;
     const size_t seq_len = static_cast<size_t>(attn.div_seq_len.GetDivisor());

--- a/gemma/vit_gemma4.cc
+++ b/gemma/vit_gemma4.cc
@@ -476,7 +476,7 @@ class VitGemma4Attention {
     const size_t qkv_dim = layer_config_.qkv_dim;
     const size_t heads = layer_config_.heads;
     HWY_ASSERT_M(heads == layer_config_.kv_heads, "Vit expects MHA");
-    const size_t kNF = FloatsPerVector();
+    const size_t kNF = hn::Lanes(hn::ScalableTag<float>());
     const size_t kRoundedKVDim = hwy::RoundUpTo(qkv_dim, 2 * kNF);
     auto& attn = activations_.attention;
     const size_t seq_len = static_cast<size_t>(attn.div_seq_len.GetDivisor());


### PR DESCRIPTION
`FloatsPerVector()` returned `hwy::VectorBytes() / sizeof(float)`, which is the vector width of the target that Highway's own library dispatches to. The flash attention kernels instead use `hn::Lanes(df)` of the target that Gemma dispatches to, and Gemma compiles a different set of targets (`GEMMA_DISABLED_TARGETS`). When the two widths differ, the transposed K/V cache is reshaped and written with one tile width but read with another.

For example, `TestAttention` in `flash_attention_test` aborts on the EMU128 target (`Assert b != T2{0}` in `hwy::DivCeil`): libhwy has no EMU128 code, so `hwy::VectorBytes()` returns 1 and the reshape factor is 0. On Arm CPUs with 256-bit SVE, such as Graviton 3, libhwy can dispatch to SVE_256 (8 floats), whereas Gemma disables SVE_256 and uses NEON_BF16 (4 floats). I have not been able to test on such hardware.

This takes the width from `hn::Lanes` in the per-target callers, passes it to `MaybeReshapeCache`, and removes `FloatsPerVector()`. The tile width is now also a compile-time constant on fixed-width targets, so `TransposeKVCacheRow`, which runs for every token, layer and KV head, no longer makes an indirect call through Highway's dispatch table.

**Testing**

- `flash_attention_test`, with each case in its own process, on AVX2 and EMU128: before, 19/20 pass and `TestAttention/EMU128` aborts; after, 20/20 pass.
- The full CMake build (all targets) succeeds.
